### PR TITLE
Feature/normalize screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 A tool for automating shiny hunting static encounter pokemon
 
 TODO: Write more here...
+
+- Specifically, describe how to get the coordinates of the screenshot crop by running 'Setup' and placing your mouse at the four sides of the emulator screen. Note specifically that we need left, top, WIDTH (right - left), HEIGHT (bottom - top)

--- a/config.py
+++ b/config.py
@@ -1,14 +1,29 @@
-############################
-##### EMULATOR CONFIGS #####
-############################
+# TODO: Need to add screenshots for the following pokemon:
+#           - Dialga
+#           - Palkia
+#           - Heatran
+#           - Regigigas
+#           - Cresselia
+#           - Darkrai
+#           - Shaymin
+#           - Arceus
+# List for reference of what can be hunted
+VALID_POKEMON_LIST = ['SETUP', 'Drifloon', 'Spiritomb', 'Rotom', 'Uxie', 'Mesprit', 'Azelf', 'Dialga', 'Palkia', 'Heatran', 'Regigigas', 'Giratina', 'Cresselia', 'Darkrai', 'Shaymin', 'Arceus']
 
-# SYSTEM CONFIG VARIABLES
-EMULATOR_EMPTY_CLICK_COORDINATES = (3022, 1246)         # x, y pixel coordinates of where to click into the emulator without clicking on the touch screen for DS emulators      THIS SHOULD BE UPDATED
-MESPRIT_HUNT_TIMEOUT = 1200                             # Amount of time in seconds before assuming the run has failed and restarting the next run                              THIS CAN BE UPDATED
-BATTLE_START_TIMEOUT = 300                              # Amount of time in seconds before assuming the run has failed and restarting the next run                              THIS CAN BE UPDATED
+###########################
+####### KEY CONFIGS #######
+###########################
+POKEMON_NAME = 'SETUP'
 TRY_COUNT = 1
 # ^^^ Current attempt number. Should start at 1 at the beginning of a hunt and be updated if you kill the app during the hunt and start it up again
 
+SCREENSHOT_CROP_COORDINDATES = (2635, 88, 2484, 1351)   # LEFT, TOP, WIDTH, HEIGHT                                                                                              THIS SHOULD BE UPDATED
+EMULATOR_EMPTY_CLICK_COORDINATES = (3022, 1246)         # x, y pixel coordinates of where to click into the emulator without clicking on the touch screen for DS emulators      THIS SHOULD BE UPDATED
+
+
+############################
+##### EMULATOR CONFIGS #####
+############################
 
 # CONTROL VARIABLES
 A_BUTTON_KEYBIND = 'x'                                  # Update to what your emulator's keyboard binds to 'A' are                                                              THIS SHOULD BE UPDATED
@@ -24,31 +39,14 @@ DOWN_BUTTON_KEYBIND = 'down'                            # Update to what your em
 LEFT_BUTTON_KEYBIND = 'left'                            # Update to what your emulator's keyboard binds to 'Move Left' are                                                      THIS SHOULD BE UPDATED
 
 
-###########################
-####### APP CONFIGS #######
-###########################
-# TODO: Need to add screenshots for the following pokemon:
-#           - Dialga
-#           - Palkia
-#           - Heatran
-#           - Regigigas
-#           - Cresselia
-#           - Darkrai
-#           - Shaymin
-#           - Arceus
-VALID_POKEMON_LIST = ['Drifloon', 'Spiritomb', 'Rotom', 'Uxie', 'Mesprit', 'Azelf', 'Dialga', 'Palkia', 'Heatran', 'Regigigas', 'Giratina', 'Cresselia', 'Darkrai', 'Shaymin', 'Arceus']
-
-
-# POKEMON NAME
-POKEMON_NAME = 'Giratina'
-
-
-# SCREENSHOT VARIABLES
-SCREENSHOT_CROP_COORDINDATES = (2635, 88, 2484, 1351)   # LEFT, TOP, WIDTH, HEIGHT                                                                                              THIS SHOULD BE UPDATED
-
+# SYSTEM CONFIG VARIABLES
+MESPRIT_HUNT_TIMEOUT = 1200                             # Amount of time in seconds before assuming the run has failed and restarting the next run                              THIS CAN BE UPDATED
+BATTLE_START_TIMEOUT = 300                              # Amount of time in seconds before assuming the run has failed and restarting the next run                              THIS CAN BE UPDATED
+MESSAGE_SPACING_SYMBOLS = '-----------------------------------------------------------------------------'
 
 # TODO: After a day of cycling through Mesprit, determine if these can be deleted
 # PIXEL CHECK VARIABLES
 # HAT_COLOR_CHECK_COORDINATES = (1550, 570)               # x, y pixel coordinates of where to check RGB for Dia's hat                                                            THIS SHOULD BE UPDATED
 # HAT_COLOR_RGB_LIST = [(219, 101, 105), (174, 81, 73), (190, 69, 65), (174, 69, 65), (134, 69, 93), (125, 60, 109), (219, 109, 125), (223, 109, 125), (223, 109, 121), (182, 89, 125), (138, 69, 121), (154, 77, 125)]
                                                         # ^^^ List of RGB colors that Dia's hat could be depending on the time of day and light shading. This should not need to be update
+

--- a/shinyHuntBot/app.py
+++ b/shinyHuntBot/app.py
@@ -347,6 +347,7 @@ def cresselia_shiny_hunt():
     """
     raise NotImplementedError('Cresselia shiny hunt method has not been implemented yet')
 
+
 def setup_crop_coordinates():
     """
     Setup method for guiding users through getting the values to set the [SCREEN_CROP_COORDINATES] config value

--- a/shinyHuntBot/app.py
+++ b/shinyHuntBot/app.py
@@ -347,6 +347,39 @@ def cresselia_shiny_hunt():
     """
     raise NotImplementedError('Cresselia shiny hunt method has not been implemented yet')
 
+def setup_crop_coordinates():
+    """
+    Setup method for guiding users through getting the values to set the [SCREEN_CROP_COORDINATES] config value
+    """
+    # Grabs the LEFT coordinate value
+    print(f'\nPlease position your mouse at the very left side of the emulator window within 5 seconds')
+    sleep(5)
+    left, _ = pyautogui.position()
+    print(f'Left value: {left}\n{config.MESSAGE_SPACING_SYMBOLS}')
+
+    # Grabs the TOP coordinate value
+    print(f'\nPlease position your mouse at the top of the actual emulator window (Just below the menu bar) within 5 seconds')
+    sleep(5)
+    _, top = pyautogui.position()
+    print(f'Top value: {top}\n{config.MESSAGE_SPACING_SYMBOLS}')
+
+    # Grabs the WIDTH coordinate value
+    print(f'\nPlease position your mouse at the very right side of the emulator window within 5 seconds')
+    sleep(5)
+    right, _ = pyautogui.position()
+    width = right - left
+    print(f'Width value: {width}\n{config.MESSAGE_SPACING_SYMBOLS}')
+
+    # Grabs the HEIGHT coordinate value
+    print(f'\nPlease position your mouse at the very bottom side of the emulator window within 5 seconds')
+    sleep(5)
+    _, bottom = pyautogui.position()
+    height = bottom - top
+    print(f'Bottom value: {bottom}\n{config.MESSAGE_SPACING_SYMBOLS}')
+
+    config_value = (left, top, width, height)
+    print(f'\nPlease replace the [SCREEN_CROP_COORDINATES] with this value (including parentheses): {config_value}')
+
 
 # TODO: Update is_shiny() method so that it compares an partial image of the hunted pokemon against the screenshot
 #        - Have a folder structure of pokemon_compare_images/$POKEMON_NAME/image.png
@@ -359,12 +392,12 @@ if __name__ == "__main__":
     if pokemon_name not in config.VALID_POKEMON_LIST and pokemon_name != 'SETUP':
         raise ValueError(f'[{pokemon_name}] is not a valid pokemon to shiny hunt! Please select from the list of available pokemon')
         
-    # Quick pause at the start of the app
-    sleep(1)
+    # Quick pause at the start of the app in case the user needs to switch to the emulator window
+    sleep(3)
     
     # Decides what startup message to print
     if pokemon_name == 'SETUP':
-        print(f'{config.MESSAGE_SPACING_SYMBOLS}\nRunning Screen Position Setup. Please position your mouse within 5 seconds\n{config.MESSAGE_SPACING_SYMBOLS}')
+        print(f'{config.MESSAGE_SPACING_SYMBOLS}\nRunning Screen Position Setup. Please ensure your emulator window is full screen and active\n{config.MESSAGE_SPACING_SYMBOLS}')
     else:
         print(f'{config.MESSAGE_SPACING_SYMBOLS}\nStarting hunt for shiny {pokemon_name}!\n{config.MESSAGE_SPACING_SYMBOLS}')
         pyautogui.click(*config.EMULATOR_EMPTY_CLICK_COORDINATES)
@@ -373,9 +406,7 @@ if __name__ == "__main__":
     # SHINY HUNT FUNCTION CALL
     match pokemon_name:
         case 'SETUP':
-            sleep(5)
-            x, y = pyautogui.position()
-            print(f'X POSITION: {x}\nY POSITION: {y}')
+            setup_crop_coordinates()
         case 'Mesprit':
             mesprit_shiny_hunt()
         case 'Cresellia':
@@ -385,6 +416,6 @@ if __name__ == "__main__":
     
     # Once the shiny hunt exits, prints the reason for exiting
     if pokemon_name == 'SETUP':
-        print(f'{config.MESSAGE_SPACING_SYMBOLS}\nPlease input the results into the [SCREENSHOT_CROP_COORDINDATES] config value\n{config.MESSAGE_SPACING_SYMBOLS}')
+        print(f'{config.MESSAGE_SPACING_SYMBOLS}\nExiting setup! Remember to set a pokemon to hunt in the config value [POKEMON_NAME] :) Happy shiny hunting!\n{config.MESSAGE_SPACING_SYMBOLS}')
     else:
         print(f'{config.MESSAGE_SPACING_SYMBOLS}\n{exit_message}\nShutting down app\n{config.MESSAGE_SPACING_SYMBOLS}')

--- a/shinyHuntBot/app.py
+++ b/shinyHuntBot/app.py
@@ -17,6 +17,8 @@ import screenshot
 ###################################################################################################
 ###################################################################################################
 
+
+
 # VARIABLES
 ###################################################################################################
 # boolean checks
@@ -30,14 +32,15 @@ try_count = config.TRY_COUNT
 failure_count = 0
 
 # Capitalize pokemon name to ensure it matches the format we expect to see
-pokemon_name = config.POKEMON_NAME.capitalize()
+pokemon_name = config.POKEMON_NAME if config.POKEMON_NAME == 'SETUP' else config.POKEMON_NAME.capitalize()
 
 ###################################################################################################
 ###################################################################################################
+
+
 
 # FUNCTIONS
 ###################################################################################################
-
 def skip_dialogue(num_times: int):
     """
     Skips through dialogue when initiating the static encounter.
@@ -73,6 +76,12 @@ def load_game():
 
 
 def check_for_recap_screen():
+    """
+    Looks to see if the game is showing the recap screen after loading a save file.
+    If it is, we cancel out of it and save the game quickly so that it stops showing up.
+    This adds time to the run where we save to stop it from appearing, but ultimately saves
+    time across all following runs
+    """
     screenshot.take_screenshot()
     if screenshot.check_for_recap_screen():
         controls.press_b()
@@ -89,7 +98,7 @@ def check_for_recap_screen():
 
 def is_in_battle() -> bool:
     """
-    Checks a particular pixel location in the battle screenshot to make sure the enemy's health bar is visible
+    Checks if we are in a battle by searching the game screenshot for the enemy's health bar
     """
     global is_in_battle
     global failure_count
@@ -99,8 +108,14 @@ def is_in_battle() -> bool:
     else:
         failure_count = 0
         return True
-    
+
+
 def is_shiny_check() -> bool:
+    """
+    Checks if the pokemon is shiny be looking to see if the pokemon's default picture is found
+    in the game screenshot. If it IS found, the pokemon is not shiny. If it IS NOT found,
+    the pokemon is likely shiny (or potentially something went wrong)
+    """
     global exit_message
     global try_count
     if screenshot.check_for_shiny(pokemon_name):
@@ -113,9 +128,16 @@ def is_shiny_check() -> bool:
 ###################################################################################################
 ###################################################################################################
 
+
+
 # MAIN CALL FUNCTIONS
 ###################################################################################################
 def static_shiny_hunt():
+    """
+    Main function for hunting static encounter pokemon. This effectively handles Rotom, Spiritomb,
+    Drifloon, and all legendaries except for Mesprit and Cresselia. Basically, we just soft reset the
+    emulator, trigger the static encounter battle, and check if the pokemon is shiny. If not, we repeat
+    """
     global try_count
     global exit_message
 
@@ -161,10 +183,13 @@ def static_shiny_hunt():
 
 
 def mesprit_shiny_hunt():
+    """
+    Main function for hunting Mesprit. Because the roaming pokemon (Mesprit and Cresselia)
+    are so unique (aka annoying), they get their entire own function. Yay!
+    """
     global try_count
     global exit_message
     
-
     while True:
         should_restart = False
         start_time = time()
@@ -314,30 +339,43 @@ def mesprit_shiny_hunt():
     print(f'This attempt took: {strftime("%M minutes and %S seconds", localtime(elapsed_time))}\n')
 
 
+# TODO: Implement cresselia_shiny_hunt
 def cresselia_shiny_hunt():
+    """
+    Main function for hunting Cresselia. Because the roaming pokemon (Cresselia and Mesprit)
+    are so unique (aka annoying), they get their entire own function. Yay!
+    """
     raise NotImplementedError('Cresselia shiny hunt method has not been implemented yet')
-
 
 
 # TODO: Update is_shiny() method so that it compares an partial image of the hunted pokemon against the screenshot
 #        - Have a folder structure of pokemon_compare_images/$POKEMON_NAME/image.png
-
 if __name__ == "__main__":
-    if pokemon_name not in config.VALID_POKEMON_LIST:
+    """
+    Main app function call. Chooses which shiny hunt function to
+    use on the the pokemon set in the [POKEMON_NAME] config value
+    """
+    # Confirms the pokemon name set in the config file is a valid option
+    if pokemon_name not in config.VALID_POKEMON_LIST and pokemon_name != 'SETUP':
         raise ValueError(f'[{pokemon_name}] is not a valid pokemon to shiny hunt! Please select from the list of available pokemon')
+        
+    # Quick pause at the start of the app
+    sleep(1)
     
-    # TODO: Look into finding the screen size of the emulator. Either by having a screenshot of my size in the repo that I search for OR finding some way to dynamically grab the window size
-
-    sleep(3) # Gives 3 seconds to make sure the emulator window is active after starting
-    # screenshot.clear_screenshots()
-    # screenshot.take_screenshot()
-
-    print(f'------------------------------------------------------------------\nStarting hunt for shiny {pokemon_name}!\n------------------------------------------------------------------')
-    pyautogui.click(*config.EMULATOR_EMPTY_CLICK_COORDINATES)
-    sleep(0.3)
+    # Decides what startup message to print
+    if pokemon_name == 'SETUP':
+        print(f'{config.MESSAGE_SPACING_SYMBOLS}\nRunning Screen Position Setup. Please position your mouse within 5 seconds\n{config.MESSAGE_SPACING_SYMBOLS}')
+    else:
+        print(f'{config.MESSAGE_SPACING_SYMBOLS}\nStarting hunt for shiny {pokemon_name}!\n{config.MESSAGE_SPACING_SYMBOLS}')
+        pyautogui.click(*config.EMULATOR_EMPTY_CLICK_COORDINATES)
+        sleep(0.3)
 
     # SHINY HUNT FUNCTION CALL
     match pokemon_name:
+        case 'SETUP':
+            sleep(5)
+            x, y = pyautogui.position()
+            print(f'X POSITION: {x}\nY POSITION: {y}')
         case 'Mesprit':
             mesprit_shiny_hunt()
         case 'Cresellia':
@@ -345,5 +383,8 @@ if __name__ == "__main__":
         case _:
             static_shiny_hunt()
     
-    # Once the app exits the while loop, prints the reason for exiting
-    print(f'------------------------------------------------------------------\n{exit_message}\nShutting down app\n------------------------------------------------------------------')
+    # Once the shiny hunt exits, prints the reason for exiting
+    if pokemon_name == 'SETUP':
+        print(f'{config.MESSAGE_SPACING_SYMBOLS}\nPlease input the results into the [SCREENSHOT_CROP_COORDINDATES] config value\n{config.MESSAGE_SPACING_SYMBOLS}')
+    else:
+        print(f'{config.MESSAGE_SPACING_SYMBOLS}\n{exit_message}\nShutting down app\n{config.MESSAGE_SPACING_SYMBOLS}')

--- a/shinyHuntBot/app.py
+++ b/shinyHuntBot/app.py
@@ -326,6 +326,8 @@ if __name__ == "__main__":
     if pokemon_name not in config.VALID_POKEMON_LIST:
         raise ValueError(f'[{pokemon_name}] is not a valid pokemon to shiny hunt! Please select from the list of available pokemon')
     
+    # TODO: Look into finding the screen size of the emulator. Either by having a screenshot of my size in the repo that I search for OR finding some way to dynamically grab the window size
+
     sleep(3) # Gives 3 seconds to make sure the emulator window is active after starting
     # screenshot.clear_screenshots()
     # screenshot.take_screenshot()

--- a/shinyHuntBot/screenshot.py
+++ b/shinyHuntBot/screenshot.py
@@ -68,8 +68,9 @@ def check_for_image(image_name: str, search_image_path: str = None, confidence: 
         try:
             search_image = Image.open(screenshot_path)
         except IOError:
-            raise IOError(f'Could not find an image at this location: [{screenshot_path}]')        
+            raise IOError(f'Could not find an image at this location: [{screenshot_path}]')
 
+    search_image = search_image.resize((2484, 1351))
     if pyautogui.locate(image, search_image, confidence=confidence) == None:
         return False
     else:

--- a/shinyHuntBot/screenshot.py
+++ b/shinyHuntBot/screenshot.py
@@ -50,7 +50,7 @@ def take_screenshot(name: str = None, region=None):
 
 
 # TODO: Set a base pixel size and have a config for screen size. Then multiply base size by value?
-def check_for_image(image_name: str, search_image_path: str = None, confidence: int = 0.999) -> bool:
+def check_for_image(image_name: str, search_image_path: str = None, confidence: int = 0.9) -> bool:
     search_image = None
     try:
         image_path = os.path.join(base_image_check_folder_path, image_name)
@@ -78,7 +78,7 @@ def check_for_image(image_name: str, search_image_path: str = None, confidence: 
     
 
 def check_for_shiny(pokemon_name: str) -> bool:
-    return not check_for_image(f'pokemon/{pokemon_name}.png')
+    return not check_for_image(f'pokemon/{pokemon_name}.png', confidence=0.97)
 
 
 def check_in_battle() -> bool:
@@ -106,7 +106,7 @@ def check_mesprit_is_here() -> bool:
             attempt += 1
 
     if is_icon_visible:
-        return check_for_image('mesprit_location_images/mesprit_location_check-1.png', image_path, confidence=0.9) or check_for_image('mesprit_location_images/mesprit_location_check-2.png', image_path, confidence=0.9)
+        return check_for_image('mesprit_location_images/mesprit_location_check-1.png', image_path, confidence=0.75) or check_for_image('mesprit_location_images/mesprit_location_check-2.png', image_path, confidence=0.75)
     else:
         return False
 


### PR DESCRIPTION
Ideally, this update will allow the application to work on monitors of any size by resizing any screenshots taken to the same size as the window that all of the image_check images were taken on. The only screen coordinate config value users will need to set now is the `SCREEN_CROP_COORDINATES` value. In order to make sure the app always gets the same screenshot for comparisons, the app needs to crop down any screenshots taken to **ONLY** contain the contents of the emulator screen (Minus the title/menu bar at the top). This also cuts out inconsistencies between different operating systems

In support of this:
- Confidence levels when locating an image in a screenshot were adjusted. **_Hopefully_** these numbers will work for all Pokemon on any size monitor. Updates can be made if this is not the case.
- A setup option was added to the `VALID_POKEMON_LIST`. If the `POKEMON_NAME` config value is set to `SETUP`, the app will guide the user through finding the values they need to set the `SCREEN_CROP_COORDINATES` config value to.
- As a bonus, formatting and documentation were improved. Woohoo!